### PR TITLE
Add flagged executable arguments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "benchmark/CGRA-Bench"]
 	path = benchmark/CGRA-Bench
 	url = https://github.com/tancheng/CGRA-Bench.git
+[submodule "third_party/cxxopts"]
+	path = third_party/cxxopts
+	url = https://github.com/jarro2783/cxxopts.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,18 +25,20 @@ add_subdirectory(remapper)
 add_executable(mapping src/mapping.cpp)
 set_property(TARGET mapping PROPERTY CXX_STANDARD 17)
 target_compile_options(mapping INTERFACE -Wall -Wextra -Wno-deprecated)
-target_link_libraries(mapping PRIVATE io entity mapper cpp_simulator)
+target_link_libraries(mapping PRIVATE io entity mapper cpp_simulator
+                                      cxxopts::cxxopts)
 
 add_executable(create_database src/create_database.cpp)
 set_property(TARGET create_database PROPERTY CXX_STANDARD 17)
 target_compile_options(create_database INTERFACE -Wall -Wextra -Wno-deprecated)
 target_link_libraries(create_database PRIVATE io entity mapper cpp_simulator
-                                              remapper)
+                                              remapper cxxopts::cxxopts)
 
 add_executable(bulk_mapping src/bulk_mapping.cpp)
 set_property(TARGET bulk_mapping PROPERTY CXX_STANDARD 17)
 target_compile_options(bulk_mapping INTERFACE -Wall -Wextra -Wno-deprecated)
-target_link_libraries(bulk_mapping PRIVATE io entity mapper cpp_simulator)
+target_link_libraries(bulk_mapping PRIVATE io entity mapper cpp_simulator
+                                           cxxopts::cxxopts)
 
 add_executable(verilator_synchronous_CGRA src/verilator_synchronous_CGRA.cpp)
 verilate(verilator_synchronous_CGRA TRACE INCLUDE_DIRS
@@ -45,9 +47,9 @@ verilate(verilator_synchronous_CGRA TRACE INCLUDE_DIRS
 set_property(TARGET verilator_synchronous_CGRA PROPERTY CXX_STANDARD 17)
 target_compile_options(verilator_synchronous_CGRA INTERFACE -Wall -Wextra
                                                             -Wno-deprecated)
-target_link_libraries(verilator_synchronous_CGRA PRIVATE io entity mapper
-                                                         cpp_simulator)
+target_link_libraries(verilator_synchronous_CGRA
+                      PRIVATE io entity mapper cpp_simulator cxxopts::cxxopts)
 add_executable(remapping src/remapping.cpp)
 set_property(TARGET remapping PROPERTY CXX_STANDARD 17)
 target_compile_options(remapping INTERFACE -Wall -Wextra -Wno-deprecated)
-target_link_libraries(remapping PRIVATE io entity remapper)
+target_link_libraries(remapping PRIVATE io entity remapper cxxopts::cxxopts)

--- a/python_tools/experiment_runner/exec.py
+++ b/python_tools/experiment_runner/exec.py
@@ -60,7 +60,15 @@ def mapping_exec(input):
   finally:
     lock.release()
 
-  subprocess.run(["/home/ubuntu/elastic_cgra_mapper/build/mapping", input.dfg_file_path, cgra_file_path, input.output_dir_path,input.mapping_config_path, str(input.timeout_s), str(input.parallel_num)])
+  subprocess.run([
+    "/home/ubuntu/elastic_cgra_mapper/build/mapping",
+    "--dfg_file", input.dfg_file_path,
+    "--cgra_file", cgra_file_path,
+    "--output_dir", input.output_dir_path,
+    "--mapper_config", input.mapping_config_path,
+    "--timeout_s", str(input.timeout_s),
+    "--parallel_num", str(input.parallel_num),
+  ])
 
   os.remove(cgra_file_path)
 
@@ -88,7 +96,15 @@ def create_database_exec(input):
   finally:
     lock.release()
 
-  subprocess.run(["/home/ubuntu/elastic_cgra_mapper/build/create_database", input.dfg_file_path, cgra_file_path, input.output_dir_path, input.mapping_config_path, str(input.db_timeout_s), str(input.max_database_size)])
+  subprocess.run([
+    "/home/ubuntu/elastic_cgra_mapper/build/create_database",
+    "--dfg_file", input.dfg_file_path,
+    "--cgra_file", cgra_file_path,
+    "--output_dir", input.output_dir_path,
+    "--mapper_config", input.mapping_config_path,
+    "--db_timeout_s", str(input.db_timeout_s),
+    "--max_database_size", str(input.max_database_size),
+  ])
 
   os.remove(cgra_file_path)
 
@@ -120,7 +136,16 @@ def remapper_exec(input):
   remapper_mode_int = remapping_type_to_int(input.remapper_mode)
 
   result = subprocess.run(
-    ["/home/ubuntu/elastic_cgra_mapper/build/remapping", input.mapping_dir_path, input.dfg_file_path, cgra_file_path, input.output_dir_path, str(remapper_mode_int), str(input.timeout_s), str(input.num_available_mappings)],
+    [
+      "/home/ubuntu/elastic_cgra_mapper/build/remapping",
+      "--database_dir", input.mapping_dir_path,
+      "--dfg_file", input.dfg_file_path,
+      "--cgra_file", cgra_file_path,
+      "--output_dir", input.output_dir_path,
+      "--remapper_mode", str(remapper_mode_int),
+      "--timeout_s", str(input.timeout_s),
+      "--num_available_mappings", str(input.num_available_mappings),
+    ],
     capture_output=True,
     text=True
   )

--- a/src/bulk_mapping.cpp
+++ b/src/bulk_mapping.cpp
@@ -1,6 +1,7 @@
 #include <time.h>
 
 #include <chrono>
+#include <cxxopts.hpp>
 #include <filesystem>
 #include <io/architecture_io.hpp>
 #include <io/dfg_io.hpp>
@@ -38,15 +39,36 @@ std::vector<entity::MRRGConfig> GetMRRGToTest(int dfg_node_num) {
 }
 
 int main(int argc, char* argv[]) {
-  if (argc != 6) {
-    std::cerr << "invalid arguments" << std::endl;
-    abort();
-  }
+  cxxopts::Options options("bulk_mapping",
+                           "Run bulk mapping over generated CGRA configs.");
+  options.add_options()("dfg_file", "Absolute path to the input DFG dot file",
+                        cxxopts::value<std::string>())(
+      "output_dir", "Absolute path to the output directory",
+      cxxopts::value<std::string>())("mapper_config",
+                                     "Path to the mapper config json file",
+                                     cxxopts::value<std::string>())(
+      "timeout_s", "Mapping timeout in seconds", cxxopts::value<double>())(
+      "h,help", "Print usage");
 
-  const std::string dfg_dot_file_path(argv[1]);
-  const std::string output_dir = argv[2];
-  const std::string mapper_config_file_path = argv[3];
-  double timeout_s = std::stod(argv[3]);
+  std::string dfg_dot_file_path;
+  std::string output_dir;
+  std::string mapper_config_file_path;
+  double timeout_s = 0;
+  try {
+    const auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      std::cout << options.help();
+      return 0;
+    }
+    dfg_dot_file_path = result["dfg_file"].as<std::string>();
+    output_dir = result["output_dir"].as<std::string>();
+    mapper_config_file_path = result["mapper_config"].as<std::string>();
+    timeout_s = result["timeout_s"].as<double>();
+  } catch (const cxxopts::exceptions::exception& e) {
+    std::cerr << "invalid arguments: " << e.what() << std::endl;
+    std::cerr << options.help();
+    return 1;
+  }
 
   assert(std::filesystem::path(dfg_dot_file_path).is_absolute());
   assert(std::filesystem::path(output_dir).is_absolute());

--- a/src/create_database.cpp
+++ b/src/create_database.cpp
@@ -1,5 +1,6 @@
 #include <time.h>
 
+#include <cxxopts.hpp>
 #include <filesystem>
 #include <fstream>
 #include <io/architecture_io.hpp>
@@ -102,17 +103,43 @@ std::vector<int> SortElementByFreqency(const std::vector<int>& vec) {
 }
 
 int main(int argc, char* argv[]) {
-  if (argc != 7) {
-    std::cerr << "invalid arguments" << std::endl;
-    abort();
-  }
+  cxxopts::Options options("create_database", "Create mapping database.");
+  options.add_options()("dfg_file", "Absolute path to the input DFG dot file",
+                        cxxopts::value<std::string>())(
+      "cgra_file", "Absolute path to the input CGRA/MRRG json file",
+      cxxopts::value<std::string>())("output_dir",
+                                     "Absolute path to the output directory",
+                                     cxxopts::value<std::string>())(
+      "mapper_config", "Path to the mapper config json file",
+      cxxopts::value<std::string>())("db_timeout_s",
+                                     "Database creation timeout in seconds",
+                                     cxxopts::value<double>())(
+      "max_database_size", "Maximum number of mappings to keep",
+      cxxopts::value<int>())("h,help", "Print usage");
 
-  const std::string dfg_dot_file_path = argv[1];
-  const std::string mrrg_file_path = argv[2];
-  const std::string output_dir = argv[3];
-  const std::string mapper_config_file_path = argv[4];
-  const double db_timeout_s = std::stod(argv[5]);
-  const int max_database_size = std::stoi(argv[6]);
+  std::string dfg_dot_file_path;
+  std::string mrrg_file_path;
+  std::string output_dir;
+  std::string mapper_config_file_path;
+  double db_timeout_s = 0;
+  int max_database_size = 0;
+  try {
+    const auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      std::cout << options.help();
+      return 0;
+    }
+    dfg_dot_file_path = result["dfg_file"].as<std::string>();
+    mrrg_file_path = result["cgra_file"].as<std::string>();
+    output_dir = result["output_dir"].as<std::string>();
+    mapper_config_file_path = result["mapper_config"].as<std::string>();
+    db_timeout_s = result["db_timeout_s"].as<double>();
+    max_database_size = result["max_database_size"].as<int>();
+  } catch (const cxxopts::exceptions::exception& e) {
+    std::cerr << "invalid arguments: " << e.what() << std::endl;
+    std::cerr << options.help();
+    return 1;
+  }
   double creating_db_time_s = 0;
 
   assert(std::filesystem::path(dfg_dot_file_path).is_absolute());

--- a/src/mapping.cpp
+++ b/src/mapping.cpp
@@ -1,6 +1,7 @@
 #include <time.h>
 
 #include <chrono>
+#include <cxxopts.hpp>
 #include <filesystem>
 #include <fstream>
 #include <io/architecture_io.hpp>
@@ -75,19 +76,44 @@ std::shared_ptr<entity::DFG> AddDFG(
 }
 
 int main(int argc, char* argv[]) {
-  if (argc != 7) {
-    std::cerr << "invalid arguments" << std::endl;
-    abort();
+  cxxopts::Options options("mapping", "Run mapping for a DFG and CGRA.");
+  options.add_options()("dfg_file", "Absolute path to the input DFG dot file",
+                        cxxopts::value<std::string>())(
+      "cgra_file", "Absolute path to the input CGRA/MRRG json file",
+      cxxopts::value<std::string>())("output_dir",
+                                     "Absolute path to the output directory",
+                                     cxxopts::value<std::string>())(
+      "mapper_config", "Path to the mapper config json file",
+      cxxopts::value<std::string>())("timeout_s", "Mapping timeout in seconds",
+                                     cxxopts::value<double>())(
+      "parallel_num", "Number of parallel DFG instances",
+      cxxopts::value<int>())("h,help", "Print usage");
+
+  std::string dfg_dot_file_path;
+  std::string mrrg_file_path;
+  std::string output_dir;
+  std::string mapper_config_file_path;
+  double timeout_s = 0;
+  int parallel_num = 0;
+  try {
+    const auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      std::cout << options.help();
+      return 0;
+    }
+    dfg_dot_file_path = result["dfg_file"].as<std::string>();
+    mrrg_file_path = result["cgra_file"].as<std::string>();
+    output_dir = result["output_dir"].as<std::string>();
+    mapper_config_file_path = result["mapper_config"].as<std::string>();
+    timeout_s = result["timeout_s"].as<double>();
+    parallel_num = result["parallel_num"].as<int>();
+  } catch (const cxxopts::exceptions::exception& e) {
+    std::cerr << "invalid arguments: " << e.what() << std::endl;
+    std::cerr << options.help();
+    return 1;
   }
 
   io::MappingLogger logger;
-
-  std::string dfg_dot_file_path = argv[1];
-  std::string mrrg_file_path = argv[2];
-  std::string output_dir = argv[3];
-  std::string mapper_config_file_path = argv[4];
-  double timeout_s = std::stod(argv[5]);
-  int parallel_num = std::stoi(argv[6]);
 
   if (!std::filesystem::exists(output_dir)) {
     std::filesystem::create_directories(output_dir);

--- a/src/remapping.cpp
+++ b/src/remapping.cpp
@@ -1,6 +1,7 @@
 #include <time.h>
 
 #include <chrono>
+#include <cxxopts.hpp>
 #include <entity/mapping.hpp>
 #include <filesystem>
 #include <fstream>
@@ -8,6 +9,7 @@
 #include <io/mapping_io.hpp>
 #include <io/output_to_log_file.hpp>
 #include <io/select_database.hpp>
+#include <iostream>
 #include <remapper/mapping_concater.hpp>
 #include <remapper/remapper.hpp>
 
@@ -33,19 +35,47 @@ io::MappingTransformOp ConvertMappingTransformOp(
 }
 
 int main(int argc, char* argv[]) {
-  if (argc != 8) {
-    std::cerr << "invalid arguments" << std::endl;
-    abort();
-  }
+  cxxopts::Options options("remapping",
+                           "Run remapping from a mapping database.");
+  options.add_options()("database_dir", "Absolute path to the database root",
+                        cxxopts::value<std::string>())(
+      "dfg_file", "Absolute path to the input DFG file",
+      cxxopts::value<std::string>())(
+      "cgra_file", "Absolute path to the input CGRA/MRRG json file",
+      cxxopts::value<std::string>())("output_dir",
+                                     "Absolute path to the output directory",
+                                     cxxopts::value<std::string>())(
+      "remapper_mode", "Remapper mode as integer", cxxopts::value<int>())(
+      "timeout_s", "Remapping timeout in seconds", cxxopts::value<double>())(
+      "num_available_mappings", "Maximum number of database mappings to use",
+      cxxopts::value<int>())("h,help", "Print usage");
 
-  std::string database_dir_path = argv[1];
-  std::string dfg_file_path = argv[2];
-  std::string mrrg_file_path = argv[3];
-  std::string output_dir = argv[4];
-  remapper::RemappingMode mode =
-      static_cast<remapper::RemappingMode>(std::stoi(argv[5]));
-  const double timeout_s = std::stod(argv[6]);
-  const int num_available_mappings = std::stoi(argv[7]);
+  std::string database_dir_path;
+  std::string dfg_file_path;
+  std::string mrrg_file_path;
+  std::string output_dir;
+  remapper::RemappingMode mode;
+  double timeout_s = 0;
+  int num_available_mappings = 0;
+  try {
+    const auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      std::cout << options.help();
+      return 0;
+    }
+    database_dir_path = result["database_dir"].as<std::string>();
+    dfg_file_path = result["dfg_file"].as<std::string>();
+    mrrg_file_path = result["cgra_file"].as<std::string>();
+    output_dir = result["output_dir"].as<std::string>();
+    mode =
+        static_cast<remapper::RemappingMode>(result["remapper_mode"].as<int>());
+    timeout_s = result["timeout_s"].as<double>();
+    num_available_mappings = result["num_available_mappings"].as<int>();
+  } catch (const cxxopts::exceptions::exception& e) {
+    std::cerr << "invalid arguments: " << e.what() << std::endl;
+    std::cerr << options.help();
+    return 1;
+  }
   const auto start_time = std::chrono::system_clock::now();
 
   assert(std::filesystem::path(database_dir_path).is_absolute());

--- a/src/verilator_synchronous_CGRA.cpp
+++ b/src/verilator_synchronous_CGRA.cpp
@@ -2,6 +2,7 @@
 #include <verilated.h>
 #include <verilated_vcd_c.h>
 
+#include <cxxopts.hpp>
 #include <io/architecture_io.hpp>
 #include <io/dfg_io.hpp>
 #include <io/mapper_config_io.hpp>
@@ -10,16 +11,40 @@
 #include <mapper/gurobi_placement_mapper.hpp>
 
 int main(int argc, char** argv) {
-  if (argc != 5) {
-    std::cerr << "invalid arguments" << std::endl;
-    abort();
-  }
+  cxxopts::Options options("verilator_synchronous_CGRA",
+                           "Run Verilator synchronous CGRA simulation.");
+  options.add_options()("dfg_file", "Absolute path to the input DFG dot file",
+                        cxxopts::value<std::string>())(
+      "cgra_file", "Absolute path to the input CGRA/MRRG json file",
+      cxxopts::value<std::string>())(
+      "mapping_file", "Absolute path to write the mapping json file",
+      cxxopts::value<std::string>())("mapper_config",
+                                     "Path to the mapper config json file",
+                                     cxxopts::value<std::string>())(
+      "fst_output_file", "Path to write the waveform output file",
+      cxxopts::value<std::string>())("h,help", "Print usage");
 
-  std::string dfg_dot_file_path = argv[1];
-  std::string mrrg_file_path = argv[2];
-  std::string mapping_file_path = argv[3];
-  std::string mapper_config_file_path = argv[4];
-  std::string fst_output_file_path = argv[5];
+  std::string dfg_dot_file_path;
+  std::string mrrg_file_path;
+  std::string mapping_file_path;
+  std::string mapper_config_file_path;
+  std::string fst_output_file_path;
+  try {
+    const auto result = options.parse(argc, argv);
+    if (result.count("help")) {
+      std::cout << options.help();
+      return 0;
+    }
+    dfg_dot_file_path = result["dfg_file"].as<std::string>();
+    mrrg_file_path = result["cgra_file"].as<std::string>();
+    mapping_file_path = result["mapping_file"].as<std::string>();
+    mapper_config_file_path = result["mapper_config"].as<std::string>();
+    fst_output_file_path = result["fst_output_file"].as<std::string>();
+  } catch (const cxxopts::exceptions::exception& e) {
+    std::cerr << "invalid arguments: " << e.what() << std::endl;
+    std::cerr << options.help();
+    return 1;
+  }
 
   // create mapping
   std::shared_ptr<entity::DFG> dfg_ptr = std::make_shared<entity::DFG>();

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,3 +1,11 @@
+set(CXXOPTS_BUILD_EXAMPLES
+    OFF
+    CACHE INTERNAL "" FORCE)
+set(CXXOPTS_BUILD_TESTS
+    OFF
+    CACHE INTERNAL "" FORCE)
+add_subdirectory(cxxopts)
+
 set(BOOST_ENABLE_CMAKE ON)
 add_subdirectory(boost)
 


### PR DESCRIPTION
## Summary
- Add cxxopts as a git submodule under `third_party/cxxopts`
- Switch executable argument parsing in `src/` from positional arguments to named flags
- Update experiment runner subprocess calls to pass the new flags

Closes #124.

## Validation
- `pre-commit run --all-files`
- `git submodule update --init --recursive`
- `cmake -S /home/ubuntu/codex-proj -B /tmp/codex-proj-build-issue124 -GNinja`
- `ninja -C /tmp/codex-proj-build-issue124`
- `c++ -std=c++17 -I/home/ubuntu/codex-proj/third_party/cxxopts/include /tmp/cxxopts_api_check.cpp -o /tmp/cxxopts_api_check`

Note: `third_party/eigen` is referenced by the existing CMake setup but is not present as a tracked gitlink in this checkout, so I cloned it locally for build validation only.