### PR TITLE
[codex] update enum names to google style

### DIFF
--- a/entity/include/entity/architecture.hpp
+++ b/entity/include/entity/architecture.hpp
@@ -60,7 +60,7 @@ struct CGRAConfig {
   std::vector<ConfigId> from_config_id_vec;
 
   CGRAConfig()
-      : operation_type(entity::OpType::NOP),
+      : operation_type(entity::OpType::kNop),
         to_config_id_vec({}),
         from_config_id_vec({}){};
   CGRAConfig(entity::OpType op_type, std::string op_name)

--- a/entity/include/entity/mapping.hpp
+++ b/entity/include/entity/mapping.hpp
@@ -25,7 +25,7 @@ class Mapping {
     if (config_map_.count(config_id) > 0) {
       return config_map_.at(config_id);
     } else {
-      return CGRAConfig(OpType::NOP, OpTypeToString(OpType::NOP));
+      return CGRAConfig(OpType::kNop, OpTypeToString(OpType::kNop));
     }
   };
   size_t GetOpNum() const;

--- a/entity/include/entity/mrrg.hpp
+++ b/entity/include/entity/mrrg.hpp
@@ -42,18 +42,18 @@ struct MRRGNodeProperty {
 
 struct MRRGEdgeProperty {};
 
-enum MRRGCGRAType {
+enum class MRRGCGRAType {
   kDefault,
   kElastic,
 };
 
-enum MRRGMemoryIOType {
+enum class MRRGMemoryIOType {
   kAll,
   kBothEnds,
   kOneEnd,
 };
 
-enum MRRGNetworkType {
+enum class MRRGNetworkType {
   kOrthogonal,
   kDiagonal,
 };

--- a/entity/include/entity/operation.hpp
+++ b/entity/include/entity/operation.hpp
@@ -4,30 +4,30 @@
 #include <vector>
 
 namespace entity {
-enum OpType {
-  ADD,
-  FADD,
-  SUB,
-  MUL,
-  FMUL,
-  DIV,
-  SDIV,
-  FDIV,
-  CONST,
-  LOAD,
-  OUTPUT,
-  STORE,
-  NOP,
-  ROUTE,
-  OR,
-  SHIFT,
-  ICMP,
-  CMPGT,
-  CMPGE,
-  CMPEQ,
-  FSUB,
-  LOOP,
-  SELECT
+enum class OpType {
+  kAdd,
+  kFAdd,
+  kSub,
+  kMul,
+  kFMul,
+  kDiv,
+  kSDiv,
+  kFDiv,
+  kConst,
+  kLoad,
+  kOutput,
+  kStore,
+  kNop,
+  kRoute,
+  kOr,
+  kShift,
+  kIcmp,
+  kCmpGt,
+  kCmpGe,
+  kCmpEq,
+  kFSub,
+  kLoop,
+  kSelect
 };
 std::string OpTypeToString(OpType op);
 OpType OpTypeFromString(std::string op_string);

--- a/entity/src/mapping.cpp
+++ b/entity/src/mapping.cpp
@@ -35,7 +35,7 @@ entity::Mapping::Mapping(
     auto GetOpTypeFromPEId = [&](int PE_id) {
       int op_id = PE_id_to_op_id_map.at(PE_id);
       if (op_id == kRouteOpId) {
-        return entity::OpType::ROUTE;
+        return entity::OpType::kRoute;
       }
       return dfg.GetNodeProperty(op_id).op;
     };
@@ -65,7 +65,7 @@ entity::Mapping::Mapping(
         config_map_.emplace(from_config_id,
                             entity::CGRAConfig(from_op_type, from_op_name));
       }
-      if (from_op_type == entity::OpType::CONST) {
+      if (from_op_type == entity::OpType::kConst) {
         int op_id = PE_id_to_op_id_map.at(from_PE_id);
         if (dfg.GetNodeProperty(op_id).const_value.has_value()) {
           config_map_[from_config_id].SetConstValue(
@@ -93,7 +93,7 @@ entity::Mapping::Mapping(
           config_map_[to_config_id].AddFromConfig(from_config_id, to_op_type,
                                                   to_op_name);
           if (searched_PE_id.count(adj_PE_id) == 0) {
-            if (to_op_type == entity::OpType::ROUTE) {
+            if (to_op_type == entity::OpType::kRoute) {
               from_PE_id_queue.push(to_PE_id);
             }
             searched_PE_id.emplace(to_PE_id);
@@ -136,7 +136,7 @@ entity::Mapping entity::GenerateMappingFromRoutingResult(
     auto GetOpTypeFromPEId = [&](int PE_id) {
       int op_id = PE_id_to_op_id_map.at(PE_id);
       if (op_id == kRouteOpId) {
-        return entity::OpType::ROUTE;
+        return entity::OpType::kRoute;
       }
       return dfg.GetNodeProperty(op_id).op;
     };
@@ -188,14 +188,14 @@ entity::Mapping entity::GenerateMappingFromRoutingResult(
       config_map_[to_config_id].AddFromConfig(from_config_id, to_op_type,
                                               to_op_name);
 
-      if (from_op_type == entity::OpType::CONST) {
+      if (from_op_type == entity::OpType::kConst) {
         if (dfg.GetNodeProperty(from_op_id).const_value.has_value()) {
           config_map_[from_config_id].SetConstValue(
               dfg.GetNodeProperty(from_op_id).const_value.value());
         }
       }
 
-      if (to_op_type != entity::OpType::ROUTE) {
+      if (to_op_type != entity::OpType::kRoute) {
         continue;
       }
 
@@ -221,7 +221,7 @@ entity::Mapping entity::GenerateMappingFromRoutingResult(
 size_t entity::Mapping::GetOpNum() const {
   size_t result = 0;
   for (const auto& id_and_config : config_map_) {
-    if (id_and_config.second.operation_type != entity::OpType::NOP) {
+    if (id_and_config.second.operation_type != entity::OpType::kNop) {
       result++;
     }
   }

--- a/entity/src/operation.cpp
+++ b/entity/src/operation.cpp
@@ -4,73 +4,73 @@
 
 std::string entity::OpTypeToString(OpType op) {
   switch (op) {
-    case entity::OpType::ADD:
+    case entity::OpType::kAdd:
       return "add";
       break;
-    case entity::OpType::FADD:
+    case entity::OpType::kFAdd:
       return "fadd";
       break;
-    case entity::OpType::SUB:
+    case entity::OpType::kSub:
       return "sub";
       break;
-    case entity::OpType::FSUB:
+    case entity::OpType::kFSub:
       return "fsub";
       break;
-    case entity::OpType::MUL:
+    case entity::OpType::kMul:
       return "mul";
       break;
-    case entity::OpType::FMUL:
+    case entity::OpType::kFMul:
       return "fmul";
       break;
-    case entity::OpType::DIV:
+    case entity::OpType::kDiv:
       return "div";
       break;
-    case entity::OpType::CONST:
+    case entity::OpType::kConst:
       return "const";
       break;
-    case entity::OpType::LOAD:
+    case entity::OpType::kLoad:
       return "load";
       break;
-    case entity::OpType::OUTPUT:
+    case entity::OpType::kOutput:
       return "output";
       break;
-    case entity::OpType::NOP:
+    case entity::OpType::kNop:
       return "nop";
       break;
-    case entity::OpType::ROUTE:
+    case entity::OpType::kRoute:
       return "route";
       break;
-    case entity::OpType::STORE:
+    case entity::OpType::kStore:
       return "store";
       break;
-    case entity::OpType::OR:
+    case entity::OpType::kOr:
       return "or";
       break;
-    case entity::OpType::SHIFT:
+    case entity::OpType::kShift:
       return "shift";
       break;
-    case entity::OpType::ICMP:
+    case entity::OpType::kIcmp:
       return "icmp";
       break;
-    case entity::OpType::CMPGT:
+    case entity::OpType::kCmpGt:
       return "cmpgt";
       break;
-    case entity::OpType::CMPGE:
+    case entity::OpType::kCmpGe:
       return "cmpge";
       break;
-    case entity::OpType::CMPEQ:
+    case entity::OpType::kCmpEq:
       return "cmpeq";
       break;
-    case entity::OpType::SDIV:
+    case entity::OpType::kSDiv:
       return "sdiv";
       break;
-    case entity::OpType::FDIV:
+    case entity::OpType::kFDiv:
       return "fdiv";
       break;
-    case entity::OpType::LOOP:
+    case entity::OpType::kLoop:
       return "loop";
       break;
-    case entity::OpType::SELECT:
+    case entity::OpType::kSelect:
       return "select";
     default:
       assert("invalid OpType");
@@ -80,51 +80,51 @@ std::string entity::OpTypeToString(OpType op) {
 
 entity::OpType entity::OpTypeFromString(std::string op_string) {
   if (op_string == "add") {
-    return entity::OpType::ADD;
+    return entity::OpType::kAdd;
   } else if (op_string == "fadd") {
-    return entity::OpType::FADD;
+    return entity::OpType::kFAdd;
   } else if (op_string == "sub") {
-    return entity::OpType::SUB;
+    return entity::OpType::kSub;
   } else if (op_string == "fsub") {
-    return entity::OpType::FSUB;
+    return entity::OpType::kFSub;
   } else if (op_string == "mul") {
-    return entity::OpType::MUL;
+    return entity::OpType::kMul;
   } else if (op_string == "fmul") {
-    return entity::OpType::FMUL;
+    return entity::OpType::kFMul;
   } else if (op_string == "div") {
-    return entity::OpType::DIV;
+    return entity::OpType::kDiv;
   } else if (op_string == "const") {
-    return entity::OpType::CONST;
+    return entity::OpType::kConst;
   } else if (op_string == "load") {
-    return entity::OpType::LOAD;
+    return entity::OpType::kLoad;
   } else if (op_string == "output") {
-    return entity::OpType::OUTPUT;
+    return entity::OpType::kOutput;
   } else if (op_string == "store") {
-    return entity::OpType::STORE;
+    return entity::OpType::kStore;
   } else if (op_string == "nop") {
-    return entity::OpType::NOP;
+    return entity::OpType::kNop;
   } else if (op_string == "route") {
-    return entity::OpType::ROUTE;
+    return entity::OpType::kRoute;
   } else if (op_string == "or") {
-    return entity::OpType::OR;
+    return entity::OpType::kOr;
   } else if (op_string == "shift") {
-    return entity::OpType::SHIFT;
+    return entity::OpType::kShift;
   } else if (op_string == "icmp") {
-    return entity::OpType::ICMP;
+    return entity::OpType::kIcmp;
   } else if (op_string == "cmpgt" || op_string == "icmpgt") {
-    return entity::OpType::CMPGT;
+    return entity::OpType::kCmpGt;
   } else if (op_string == "cmpge" || op_string == "icmpge") {
-    return entity::OpType::CMPGE;
+    return entity::OpType::kCmpGe;
   } else if (op_string == "cmpeq" || op_string == "icmpeq") {
-    return entity::OpType::CMPEQ;
+    return entity::OpType::kCmpEq;
   } else if (op_string == "sdiv") {
-    return entity::OpType::SDIV;
+    return entity::OpType::kSDiv;
   } else if (op_string == "fdiv") {
-    return entity::OpType::FDIV;
+    return entity::OpType::kFDiv;
   } else if (op_string == "loop") {
-    return entity::OpType::LOOP;
+    return entity::OpType::kLoop;
   } else if (op_string == "select") {
-    return entity::OpType::SELECT;
+    return entity::OpType::kSelect;
   } else {
     std::string message = "invalid op string: " + op_string;
     std::cerr << message << std::endl;
@@ -134,36 +134,36 @@ entity::OpType entity::OpTypeFromString(std::string op_string) {
 
 std::vector<entity::OpType> entity::GetAllOperations() {
   return std::vector<OpType>(
-      {entity::OpType::ADD,   entity::OpType::FADD,  entity::OpType::SUB,
-       entity::OpType::FSUB,  entity::OpType::MUL,   entity::OpType::FMUL,
-       entity::OpType::DIV,   entity::OpType::SDIV,  entity::OpType::FDIV,
-       entity::OpType::CONST, entity::OpType::LOAD,  entity::OpType::OUTPUT,
-       entity::OpType::STORE, entity::OpType::NOP,   entity::OpType::ROUTE,
-       entity::OpType::OR,    entity::OpType::SHIFT, entity::OpType::ICMP,
-       entity::OpType::CMPGT, entity::OpType::CMPGE, entity::OpType::CMPEQ,
-       entity::OpType::SELECT});
+      {entity::OpType::kAdd,   entity::OpType::kFAdd,  entity::OpType::kSub,
+       entity::OpType::kFSub,  entity::OpType::kMul,   entity::OpType::kFMul,
+       entity::OpType::kDiv,   entity::OpType::kSDiv,  entity::OpType::kFDiv,
+       entity::OpType::kConst, entity::OpType::kLoad,  entity::OpType::kOutput,
+       entity::OpType::kStore, entity::OpType::kNop,   entity::OpType::kRoute,
+       entity::OpType::kOr,    entity::OpType::kShift, entity::OpType::kIcmp,
+       entity::OpType::kCmpGt, entity::OpType::kCmpGe, entity::OpType::kCmpEq,
+       entity::OpType::kSelect});
 };
 
 std::vector<entity::OpType> entity::GetAllOperationsExceptMemoryAccess() {
   return std::vector<OpType>(
-      {entity::OpType::ADD, entity::OpType::FADD, entity::OpType::SUB,
-       entity::OpType::FSUB, entity::OpType::MUL, entity::OpType::FMUL,
-       entity::OpType::DIV, entity::OpType::SDIV, entity::OpType::FDIV,
-       entity::OpType::CONST, entity::OpType::NOP, entity::OpType::ROUTE,
-       entity::OpType::OR, entity::OpType::SHIFT, entity::OpType::ICMP,
-       entity::OpType::CMPGT, entity::OpType::CMPGE, entity::OpType::CMPEQ,
-       entity::OpType::SELECT});
+      {entity::OpType::kAdd, entity::OpType::kFAdd, entity::OpType::kSub,
+       entity::OpType::kFSub, entity::OpType::kMul, entity::OpType::kFMul,
+       entity::OpType::kDiv, entity::OpType::kSDiv, entity::OpType::kFDiv,
+       entity::OpType::kConst, entity::OpType::kNop, entity::OpType::kRoute,
+       entity::OpType::kOr, entity::OpType::kShift, entity::OpType::kIcmp,
+       entity::OpType::kCmpGt, entity::OpType::kCmpGe, entity::OpType::kCmpEq,
+       entity::OpType::kSelect});
 };
 
 std::vector<entity::OpType> entity::GetLoopOperations() {
-  return std::vector<OpType>({entity::OpType::LOOP});
+  return std::vector<OpType>({entity::OpType::kLoop});
 };
 
 bool entity::IsMemoryAccessOperation(OpType op) {
-  return (op == entity::OpType::LOAD || op == entity::OpType::STORE ||
-          op == entity::OpType::OUTPUT);
+  return (op == entity::OpType::kLoad || op == entity::OpType::kStore ||
+          op == entity::OpType::kOutput);
 };
 
 bool entity::IsDFGOp(OpType op) {
-  return !(op == entity::OpType::NOP || op == entity::OpType::ROUTE);
+  return !(op == entity::OpType::kNop || op == entity::OpType::kRoute);
 };

--- a/io/src/mapping_io.cpp
+++ b/io/src/mapping_io.cpp
@@ -45,7 +45,7 @@ struct ConfigIOStruct {
 
   ConfigIOStruct(int context_id_) {
     context_id = context_id_;
-    operation_type = entity::OpTypeToString(entity::OpType::NOP);
+    operation_type = entity::OpTypeToString(entity::OpType::kNop);
     operation_name = "nop";
     const_value = 0;
   }

--- a/mapper/test/gurobi_mapper_test.cpp
+++ b/mapper/test/gurobi_mapper_test.cpp
@@ -10,7 +10,7 @@ TEST(MapperTest, gurobi_placement_mapper_test) {
   entity::DFGGraph g;
   for (int i = 0; i < node_num; i++) {
     auto v1 = boost::add_vertex(g);
-    g[v1].op = entity::OpType::ADD;
+    g[v1].op = entity::OpType::kAdd;
   }
 
   boost::graph_traits<entity::DFGGraph>::edge_descriptor e;
@@ -52,7 +52,7 @@ TEST(MapperTest, gurobi_mapper_test) {
   entity::DFGGraph g;
   for (int i = 0; i < node_num; i++) {
     auto v1 = boost::add_vertex(g);
-    g[v1].op = entity::OpType::ADD;
+    g[v1].op = entity::OpType::kAdd;
   }
 
   boost::graph_traits<entity::DFGGraph>::edge_descriptor e;

--- a/remapper/include/remapper/algorithm_entity.hpp
+++ b/remapper/include/remapper/algorithm_entity.hpp
@@ -13,9 +13,9 @@ class Rectangle {
   int context_size;
 };
 
-enum PEType {
-  MEMORY_ACCESS,
-  NON_MEMORY_ACCESS,
+enum class PEType {
+  kMemoryAccess,
+  kNonMemoryAccess,
 };
 
 class MappingMatrix : public Rectangle {
@@ -81,18 +81,18 @@ class CGRAMatrix : public Rectangle {
     }
 
     if (mrrg_config_.memory_io == entity::MRRGMemoryIOType::kAll) {
-      return remapper::PEType::MEMORY_ACCESS;
+      return remapper::PEType::kMemoryAccess;
     } else if (mrrg_config_.memory_io == entity::MRRGMemoryIOType::kOneEnd) {
       if (column_id == 0) {
-        return remapper::PEType::MEMORY_ACCESS;
+        return remapper::PEType::kMemoryAccess;
       }
     } else if (mrrg_config_.memory_io == entity::MRRGMemoryIOType::kBothEnds) {
       if (column_id == 0 || column_id == column_size - 1) {
-        return remapper::PEType::MEMORY_ACCESS;
+        return remapper::PEType::kMemoryAccess;
       }
     }
 
-    return remapper::PEType::NON_MEMORY_ACCESS;
+    return remapper::PEType::kNonMemoryAccess;
   }
 
  private:

--- a/remapper/include/remapper/mapping_transform_op.hpp
+++ b/remapper/include/remapper/mapping_transform_op.hpp
@@ -3,15 +3,15 @@
 #include <vector>
 
 namespace remapper {
-enum RotateOp {
-  TopIsTop = 0,
-  TopIsRight = 1,
-  TopIsBottom = 2,
-  TopIsLeft = 3,
-  TopIsTopMirror = 4,
-  TopIsRightMirror = 5,
-  TopIsBottomMirror = 6,
-  TopIsLeftMirror = 7
+enum class RotateOp {
+  kTopIsTop = 0,
+  kTopIsRight = 1,
+  kTopIsBottom = 2,
+  kTopIsLeft = 3,
+  kTopIsTopMirror = 4,
+  kTopIsRightMirror = 5,
+  kTopIsBottomMirror = 6,
+  kTopIsLeftMirror = 7
 };
 
 std::string RotateOpToString(RotateOp rotate_op);
@@ -20,16 +20,16 @@ RotateOp CombineRotateOp(const RotateOp& lhs, const RotateOp& rhs);
 
 constexpr int kRotateOpNum = 8;
 
-enum class RotateType { All = 0, WithoutMirror = 1 };
+enum class RotateType { kAll = 0, kWithoutMirror = 1 };
 
 const std::vector<RotateOp> kAllRotateOpVec = {
-    RotateOp::TopIsTop,          RotateOp::TopIsRight,
-    RotateOp::TopIsBottom,       RotateOp::TopIsLeft,
-    RotateOp::TopIsTopMirror,    RotateOp::TopIsRightMirror,
-    RotateOp::TopIsBottomMirror, RotateOp::TopIsLeftMirror};
+    RotateOp::kTopIsTop,          RotateOp::kTopIsRight,
+    RotateOp::kTopIsBottom,       RotateOp::kTopIsLeft,
+    RotateOp::kTopIsTopMirror,    RotateOp::kTopIsRightMirror,
+    RotateOp::kTopIsBottomMirror, RotateOp::kTopIsLeftMirror};
 const std::vector<RotateOp> kAllRotateOpVecWithoutMirror = {
-    RotateOp::TopIsTop, RotateOp::TopIsRight, RotateOp::TopIsBottom,
-    RotateOp::TopIsLeft};
+    RotateOp::kTopIsTop, RotateOp::kTopIsRight, RotateOp::kTopIsBottom,
+    RotateOp::kTopIsLeft};
 
 struct MappingTransformOp {
   MappingTransformOp()

--- a/remapper/include/remapper/remapper.hpp
+++ b/remapper/include/remapper/remapper.hpp
@@ -6,7 +6,7 @@
 #include <string>
 
 namespace remapper {
-enum RemappingMode { FullSearch, Greedy, DP, DPAndFullSearch };
+enum class RemappingMode { kFullSearch, kGreedy, kDP, kDPAndFullSearch };
 
 std::string RemappingModeToString(RemappingMode mode);
 

--- a/remapper/include/remapper/remapping_manager.hpp
+++ b/remapper/include/remapper/remapping_manager.hpp
@@ -7,7 +7,7 @@ class RemappingManager {
  public:
   RemappingManager(
       const remapper::CGRAMatrix& cgra_matrix,
-      const remapper::RotateType& rotate_type = remapper::RotateType::All)
+      const remapper::RotateType& rotate_type = remapper::RotateType::kAll)
       : cgra_matrix_(cgra_matrix), rotate_type_(rotate_type){};
   ~RemappingManager() = default;
   void SetMappingMatrix(const remapper::MappingMatrix& mapping_matrix);

--- a/remapper/src/algorithm/dp_remapper.cpp
+++ b/remapper/src/algorithm/dp_remapper.cpp
@@ -412,7 +412,7 @@ class DPRemappingHelper {
     if (need_rotation) {
       remapper::RotateOp new_rotate_op = remapper::CombineRotateOp(
           static_cast<remapper::RotateOp>(placement.rotation_type),
-          remapper::RotateOp::TopIsBottom);
+          remapper::RotateOp::kTopIsBottom);
       new_placement.rotation_type = static_cast<int>(new_rotate_op);
     } else {
       new_placement.rotation_type = placement.rotation_type;

--- a/remapper/src/algorithm_entity.cpp
+++ b/remapper/src/algorithm_entity.cpp
@@ -56,7 +56,7 @@ remapper::MappingMatrix::MappingMatrix(
            context_id < mapping.GetMRRGConfig().context_size; context_id++) {
         const entity::ConfigId config_id(row_id, column_id, context_id);
         const auto config = mapping.GetConfig(config_id);
-        if (config.operation_type != entity::OpType::NOP) {
+        if (config.operation_type != entity::OpType::kNop) {
           pe_op_count++;
         }
         if (entity::IsDFGOp(config.operation_type)) {
@@ -131,21 +131,21 @@ remapper::MappingMatrix::MappingMatrix(
 
 Eigen::MatrixXi remapper::MappingMatrix::GetRotatedMatrix(
     const Eigen::MatrixXi& matrix, remapper::RotateOp rotate_op) const {
-  if (rotate_op == remapper::RotateOp::TopIsTop) {
+  if (rotate_op == remapper::RotateOp::kTopIsTop) {
     return matrix;
-  } else if (rotate_op == remapper::RotateOp::TopIsLeft) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsLeft) {
     return matrix.transpose().colwise().reverse().eval();
-  } else if (rotate_op == remapper::RotateOp::TopIsBottom) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsBottom) {
     return matrix.colwise().reverse().rowwise().reverse().eval();
-  } else if (rotate_op == remapper::RotateOp::TopIsRight) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsRight) {
     return matrix.colwise().reverse().transpose().eval();
-  } else if (rotate_op == remapper::RotateOp::TopIsTopMirror) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsTopMirror) {
     return matrix.rowwise().reverse().eval();
-  } else if (rotate_op == remapper::RotateOp::TopIsLeftMirror) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsLeftMirror) {
     return matrix.transpose().colwise().reverse().rowwise().reverse().eval();
-  } else if (rotate_op == remapper::RotateOp::TopIsBottomMirror) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsBottomMirror) {
     return matrix.colwise().reverse().eval();
-  } else if (rotate_op == remapper::RotateOp::TopIsRightMirror) {
+  } else if (rotate_op == remapper::RotateOp::kTopIsRightMirror) {
     return matrix.transpose().eval();
   } else {
     assert(false);

--- a/remapper/src/mapping_concater.cpp
+++ b/remapper/src/mapping_concater.cpp
@@ -44,7 +44,8 @@ entity::Mapping remapper::MappingConcater(
     };
 
     for (const auto& id_config_pair : rotated_mapping.GetConfigMap()) {
-      if (id_config_pair.second.operation_type == entity::OpType::NOP) continue;
+      if (id_config_pair.second.operation_type == entity::OpType::kNop)
+        continue;
       entity::ConfigId shifted_id = ShiftConfigId(id_config_pair.first);
       assert(shifted_id.context_id < target_mrrg_config.context_size);
       tmp_mapping_matrix(shifted_id.row_id, shifted_id.column_id)++;
@@ -67,9 +68,9 @@ entity::Mapping remapper::MappingConcater(
 
   if (target_mrrg_config.memory_io == entity::MRRGMemoryIOType::kBothEnds) {
     for (const auto& config : result_config_map) {
-      if (config.second.operation_type == entity::OpType::STORE ||
-          config.second.operation_type == entity::OpType::LOAD ||
-          config.second.operation_type == entity::OpType::OUTPUT) {
+      if (config.second.operation_type == entity::OpType::kStore ||
+          config.second.operation_type == entity::OpType::kLoad ||
+          config.second.operation_type == entity::OpType::kOutput) {
         assert(config.first.column_id == 0 ||
                config.first.column_id == target_mrrg_config.column - 1);
       }

--- a/remapper/src/mapping_transform_op.cpp
+++ b/remapper/src/mapping_transform_op.cpp
@@ -37,21 +37,21 @@ remapper::RotateOp remapper::CombineRotateOp(const remapper::RotateOp& lhs,
 
 std::string remapper::RotateOpToString(remapper::RotateOp rotate_op) {
   switch (rotate_op) {
-    case remapper::RotateOp::TopIsTop:
+    case remapper::RotateOp::kTopIsTop:
       return "TopIsTop";
-    case remapper::RotateOp::TopIsRight:
+    case remapper::RotateOp::kTopIsRight:
       return "TopIsRight";
-    case remapper::RotateOp::TopIsBottom:
+    case remapper::RotateOp::kTopIsBottom:
       return "TopIsBottom";
-    case remapper::RotateOp::TopIsLeft:
+    case remapper::RotateOp::kTopIsLeft:
       return "TopIsLeft";
-    case remapper::RotateOp::TopIsTopMirror:
+    case remapper::RotateOp::kTopIsTopMirror:
       return "TopIsTopMirror";
-    case remapper::RotateOp::TopIsRightMirror:
+    case remapper::RotateOp::kTopIsRightMirror:
       return "TopIsRightMirror";
-    case remapper::RotateOp::TopIsBottomMirror:
+    case remapper::RotateOp::kTopIsBottomMirror:
       return "TopIsBottomMirror";
-    case remapper::RotateOp::TopIsLeftMirror:
+    case remapper::RotateOp::kTopIsLeftMirror:
       return "TopIsLeftMirror";
     default:
       return "Unknown";

--- a/remapper/src/remapper.cpp
+++ b/remapper/src/remapper.cpp
@@ -12,13 +12,13 @@
 
 std::string remapper::RemappingModeToString(RemappingMode mode) {
   switch (mode) {
-    case RemappingMode::FullSearch:
+    case RemappingMode::kFullSearch:
       return "full_search";
-    case RemappingMode::Greedy:
+    case RemappingMode::kGreedy:
       return "greedy";
-    case RemappingMode::DP:
+    case RemappingMode::kDP:
       return "dp";
-    case RemappingMode::DPAndFullSearch:
+    case RemappingMode::kDPAndFullSearch:
       return "dp_and_full_search";
   }
 }
@@ -26,13 +26,13 @@ std::string remapper::RemappingModeToString(RemappingMode mode) {
 remapper::RemappingMode remapper::RemappingModeFromString(
     const std::string& mode_str) {
   if (mode_str == "full_search") {
-    return RemappingMode::FullSearch;
+    return RemappingMode::kFullSearch;
   } else if (mode_str == "greedy") {
-    return RemappingMode::Greedy;
+    return RemappingMode::kGreedy;
   } else if (mode_str == "dp") {
-    return RemappingMode::DP;
+    return RemappingMode::kDP;
   } else if (mode_str == "dp_and_full_search") {
-    return RemappingMode::DPAndFullSearch;
+    return RemappingMode::kDPAndFullSearch;
   } else {
     assert(false);
   }
@@ -62,20 +62,20 @@ remapper::RemappingResult remapper::Remapper::Remapping(
   RemappingResult result;
   const auto start_time = std::chrono::system_clock::now();
   switch (mode) {
-    case RemappingMode::FullSearch:
+    case RemappingMode::kFullSearch:
       result = remapper::FullSearchRemapping(mapping_matrix_vec, cgra_matrix,
                                              target_parallel_num, log_file,
                                              timeout_s);
       break;
-    case RemappingMode::Greedy:
+    case RemappingMode::kGreedy:
       result = remapper::GreedyRemapping(mapping_matrix_vec, cgra_matrix,
                                          target_parallel_num, log_file);
       break;
-    case RemappingMode::DP:
+    case RemappingMode::kDP:
       result = remapper::DPRemapping(mapping_matrix_vec, cgra_matrix,
                                      target_parallel_num, log_file);
       break;
-    case RemappingMode::DPAndFullSearch:
+    case RemappingMode::kDPAndFullSearch:
       result = remapper::DPAndFullSearchElasticRemapping(
           mapping_matrix_vec, cgra_matrix, target_parallel_num, log_file);
       break;
@@ -99,5 +99,6 @@ void remapper::OutputToLogFile(entity::MRRGConfig mapping_mrrg_config,
   log_file << "context_size: " << mapping_mrrg_config.context_size << std::endl;
   log_file << "row shift: " << transform_op.row << std::endl;
   log_file << "column shift: " << transform_op.column << std::endl;
-  log_file << "rotation: " << transform_op.rotate_op << std::endl;
+  log_file << "rotation: " << static_cast<int>(transform_op.rotate_op)
+           << std::endl;
 }

--- a/remapper/src/remapping_manager.cpp
+++ b/remapper/src/remapping_manager.cpp
@@ -4,7 +4,7 @@ void RemappingManager::SetMappingMatrix(
     const remapper::MappingMatrix& mapping_matrix) {
   tmp_mapping_matrix_ = mapping_matrix;
   prev_transform_op_ =
-      remapper::MappingTransformOp(0, 0, remapper::RotateOp::TopIsTop);
+      remapper::MappingTransformOp(0, 0, remapper::RotateOp::kTopIsTop);
 };
 
 remapper::MappingTransformOp RemappingManager::GetNextMappingTransformOp() {

--- a/remapper/src/transform.cpp
+++ b/remapper/src/transform.cpp
@@ -6,42 +6,42 @@ entity::ConfigId remapper::RotateConfigId(
     const remapper::RotateOp& rotate_op) {
   int rotated_row_id, rotated_column_id;
   switch (rotate_op) {
-    case remapper::RotateOp::TopIsRight:
+    case remapper::RotateOp::kTopIsRight:
       rotated_row_id = config_id.column_id;
       rotated_column_id = target_mrrg_config.row - 1 - config_id.row_id;
       break;
 
-    case remapper::RotateOp::TopIsBottom:
+    case remapper::RotateOp::kTopIsBottom:
       rotated_row_id = target_mrrg_config.row - 1 - config_id.row_id;
       rotated_column_id = target_mrrg_config.column - 1 - config_id.column_id;
       break;
 
-    case remapper::RotateOp::TopIsLeft:
+    case remapper::RotateOp::kTopIsLeft:
       rotated_row_id = target_mrrg_config.column - 1 - config_id.column_id;
       rotated_column_id = config_id.row_id;
       break;
 
-    case remapper::RotateOp::TopIsTop:
+    case remapper::RotateOp::kTopIsTop:
       rotated_row_id = config_id.row_id;
       rotated_column_id = config_id.column_id;
       break;
 
-    case remapper::RotateOp::TopIsRightMirror:
+    case remapper::RotateOp::kTopIsRightMirror:
       rotated_row_id = config_id.column_id;
       rotated_column_id = config_id.row_id;
       break;
 
-    case remapper::RotateOp::TopIsBottomMirror:
+    case remapper::RotateOp::kTopIsBottomMirror:
       rotated_row_id = target_mrrg_config.row - 1 - config_id.row_id;
       rotated_column_id = config_id.column_id;
       break;
 
-    case remapper::RotateOp::TopIsLeftMirror:
+    case remapper::RotateOp::kTopIsLeftMirror:
       rotated_row_id = target_mrrg_config.column - 1 - config_id.column_id;
       rotated_column_id = target_mrrg_config.row - 1 - config_id.row_id;
       break;
 
-    case remapper::RotateOp::TopIsTopMirror:
+    case remapper::RotateOp::kTopIsTopMirror:
       rotated_row_id = config_id.row_id;
       rotated_column_id = target_mrrg_config.column - 1 - config_id.column_id;
       break;
@@ -56,42 +56,42 @@ entity::MRRGConfig RotateMRRGConfig(const entity::MRRGConfig& mrrg_config,
   entity::MRRGConfig rotated_mrrg_config = mrrg_config;
 
   switch (rotate_op) {
-    case remapper::RotateOp::TopIsRight:
+    case remapper::RotateOp::kTopIsRight:
       rotated_mrrg_config.column = mrrg_config.row;
       rotated_mrrg_config.row = mrrg_config.column;
       break;
 
-    case remapper::RotateOp::TopIsBottom:
+    case remapper::RotateOp::kTopIsBottom:
       rotated_mrrg_config.column = mrrg_config.column;
       rotated_mrrg_config.row = mrrg_config.row;
       break;
 
-    case remapper::RotateOp::TopIsLeft:
+    case remapper::RotateOp::kTopIsLeft:
       rotated_mrrg_config.column = mrrg_config.row;
       rotated_mrrg_config.row = mrrg_config.column;
       break;
 
-    case remapper::RotateOp::TopIsTop:
+    case remapper::RotateOp::kTopIsTop:
       rotated_mrrg_config.column = mrrg_config.column;
       rotated_mrrg_config.row = mrrg_config.row;
       break;
 
-    case remapper::RotateOp::TopIsRightMirror:
+    case remapper::RotateOp::kTopIsRightMirror:
       rotated_mrrg_config.column = mrrg_config.row;
       rotated_mrrg_config.row = mrrg_config.column;
       break;
 
-    case remapper::RotateOp::TopIsBottomMirror:
+    case remapper::RotateOp::kTopIsBottomMirror:
       rotated_mrrg_config.column = mrrg_config.column;
       rotated_mrrg_config.row = mrrg_config.row;
       break;
 
-    case remapper::RotateOp::TopIsLeftMirror:
+    case remapper::RotateOp::kTopIsLeftMirror:
       rotated_mrrg_config.column = mrrg_config.row;
       rotated_mrrg_config.row = mrrg_config.column;
       break;
 
-    case remapper::RotateOp::TopIsTopMirror:
+    case remapper::RotateOp::kTopIsTopMirror:
       rotated_mrrg_config.column = mrrg_config.column;
       rotated_mrrg_config.row = mrrg_config.row;
       break;
@@ -129,20 +129,20 @@ entity::Mapping remapper::MappingRotater(const entity::Mapping& mapping,
 }
 
 remapper::RotateOp remapper::Rotate180(const remapper::RotateOp& tmp) {
-  if (tmp == remapper::RotateOp::TopIsTop)
-    return remapper::RotateOp::TopIsBottom;
-  if (tmp == remapper::RotateOp::TopIsBottom)
-    return remapper::RotateOp::TopIsTop;
-  if (tmp == remapper::RotateOp::TopIsRight)
-    return remapper::RotateOp::TopIsLeft;
-  if (tmp == remapper::RotateOp::TopIsLeft)
-    return remapper::RotateOp::TopIsRight;
-  if (tmp == remapper::RotateOp::TopIsTopMirror)
-    return remapper::RotateOp::TopIsBottomMirror;
-  if (tmp == remapper::RotateOp::TopIsBottomMirror)
-    return remapper::RotateOp::TopIsTopMirror;
-  if (tmp == remapper::RotateOp::TopIsRightMirror)
-    return remapper::RotateOp::TopIsLeftMirror;
-  if (tmp == remapper::RotateOp::TopIsLeftMirror)
-    return remapper::RotateOp::TopIsRightMirror;
+  if (tmp == remapper::RotateOp::kTopIsTop)
+    return remapper::RotateOp::kTopIsBottom;
+  if (tmp == remapper::RotateOp::kTopIsBottom)
+    return remapper::RotateOp::kTopIsTop;
+  if (tmp == remapper::RotateOp::kTopIsRight)
+    return remapper::RotateOp::kTopIsLeft;
+  if (tmp == remapper::RotateOp::kTopIsLeft)
+    return remapper::RotateOp::kTopIsRight;
+  if (tmp == remapper::RotateOp::kTopIsTopMirror)
+    return remapper::RotateOp::kTopIsBottomMirror;
+  if (tmp == remapper::RotateOp::kTopIsBottomMirror)
+    return remapper::RotateOp::kTopIsTopMirror;
+  if (tmp == remapper::RotateOp::kTopIsRightMirror)
+    return remapper::RotateOp::kTopIsLeftMirror;
+  if (tmp == remapper::RotateOp::kTopIsLeftMirror)
+    return remapper::RotateOp::kTopIsRightMirror;
 }

--- a/remapper/test/remapper_test.cpp
+++ b/remapper/test/remapper_test.cpp
@@ -46,20 +46,20 @@ TEST(RemapperTest, remapper_test) {
   std::ofstream log_file(kDatabaseDirPath / "test_remapper.log");
 
   // test dynamic programming remapping
-  const auto remapping_result_dp =
-      remapper::Remapper::Remapping(mapping_vec, mrrg_config, parallel_num,
-                                    log_file, remapper::RemappingMode::DP, 100);
+  const auto remapping_result_dp = remapper::Remapper::Remapping(
+      mapping_vec, mrrg_config, parallel_num, log_file,
+      remapper::RemappingMode::kDP, 100);
   EXPECT_EQ(remapping_result_dp.result_mapping_id_vec.size(), 3);
 
   // test greedy remapping
   const auto remapping_result_greedy = remapper::Remapper::Remapping(
       mapping_vec, mrrg_config, parallel_num, log_file,
-      remapper::RemappingMode::Greedy, 100);
+      remapper::RemappingMode::kGreedy, 100);
   EXPECT_EQ(remapping_result_greedy.result_mapping_id_vec.size(), 3);
 
   // test full search remapping
   const auto remapping_result_full_search = remapper::Remapper::Remapping(
       mapping_vec, mrrg_config, parallel_num, log_file,
-      remapper::RemappingMode::FullSearch, 100);
+      remapper::RemappingMode::kFullSearch, 100);
   EXPECT_EQ(remapping_result_full_search.result_mapping_id_vec.size(), 4);
 }

--- a/simulator/cpp/include/cpp_simulator/operation.hpp
+++ b/simulator/cpp/include/cpp_simulator/operation.hpp
@@ -10,31 +10,31 @@ T ExecuteOperation(entity::OpType op_type, T input_1, T input_2,
                    entity::CGRAConfig cgra_config) {
   T output;
   switch (op_type) {
-    case entity::OpType::ADD:
+    case entity::OpType::kAdd:
       output = input_1 + input_2;
       break;
-    case entity::OpType::SUB:
+    case entity::OpType::kSub:
       output = input_1 - input_2;
       break;
-    case entity::OpType::MUL:
+    case entity::OpType::kMul:
       output = input_1 * input_2;
       break;
-    case entity::OpType::DIV:
+    case entity::OpType::kDiv:
       output = input_1 / input_2;
       break;
-    case entity::OpType::CONST:
+    case entity::OpType::kConst:
       output = cgra_config.const_value;
       break;
-    case entity::OpType::LOAD:
+    case entity::OpType::kLoad:
       output = memory_ptr->Load(input_1);
       break;
-    case entity::OpType::OUTPUT:
+    case entity::OpType::kOutput:
       output = input_1;
       break;
-    case entity::OpType::NOP:
+    case entity::OpType::kNop:
       output = 0;
       break;
-    case entity::OpType::ROUTE:
+    case entity::OpType::kRoute:
       output = input_1;
       break;
     default:

--- a/simulator/cpp/src/CGRA.cpp
+++ b/simulator/cpp/src/CGRA.cpp
@@ -62,7 +62,7 @@ void simulator::CGRA::SetConfig(std::shared_ptr<entity::Mapping> mapping) {
     PE_array_[tmp_config_id.row_id][tmp_config_id.column_id].SetConfig(
         tmp_config_id.context_id, config_map[tmp_config_id]);
     entity::CGRAConfig tmp_config = itr->second;
-    if (tmp_config.operation_type == entity::OpType::OUTPUT) {
+    if (tmp_config.operation_type == entity::OpType::kOutput) {
       output_config_id_ = tmp_config_id;
     }
   }

--- a/simulator/cpp/src/elastic_CGRA.cpp
+++ b/simulator/cpp/src/elastic_CGRA.cpp
@@ -66,7 +66,7 @@ void simulator::ElasticCGRA::SetConfig(
     PE_array_[tmp_config_id.row_id][tmp_config_id.column_id].SetConfig(
         tmp_config_id.context_id, config_map[tmp_config_id]);
     entity::CGRAConfig tmp_config = itr->second;
-    if (tmp_config.operation_type == entity::OpType::OUTPUT) {
+    if (tmp_config.operation_type == entity::OpType::kOutput) {
       output_config_id_ = tmp_config_id;
     }
   }

--- a/simulator/cpp/src/elastic_PE.cpp
+++ b/simulator/cpp/src/elastic_PE.cpp
@@ -59,7 +59,7 @@ void simulator::ElasticPE::SetConfig(int id, entity::CGRAConfig config) {
     input_mux_2_.SetConfig(id, config.from_config_id_vec[1].GetPositionId());
   }
 
-  if (config.operation_type == entity::OpType::ROUTE) {
+  if (config.operation_type == entity::OpType::kRoute) {
     output_mux_.SetConfig(id, kBypassPosition);
     bypass_mux_.SetConfig(id, config.from_config_id_vec[0].GetPositionId());
   } else {

--- a/simulator/cpp/test/simulator_test.cpp
+++ b/simulator/cpp/test/simulator_test.cpp
@@ -67,7 +67,7 @@ TEST(SimulatorTest, simulator_default_result_test) {
 
   int output_config_id;
   for (auto config_pair : result.mapping_ptr->GetConfigMap()) {
-    if (config_pair.second.operation_type == entity::OpType::OUTPUT) {
+    if (config_pair.second.operation_type == entity::OpType::kOutput) {
       output_config_id = config_pair.first.context_id;
     }
   }

--- a/simulator/verilog/test/verilog_synchronous_CGRA_test.cpp
+++ b/simulator/verilog/test/verilog_synchronous_CGRA_test.cpp
@@ -26,15 +26,15 @@ TEST(VerilogSimulatorTest, synchronous_CGRA_test) {
   };
 
   auto GetOpIndex = [](entity::OpType op) {
-    if (op == entity::OpType::NOP) return 0;
-    if (op == entity::OpType::ADD) return 1;
-    if (op == entity::OpType::SUB) return 2;
-    if (op == entity::OpType::MUL) return 3;
-    if (op == entity::OpType::DIV) return 4;
-    if (op == entity::OpType::CONST) return 5;
-    if (op == entity::OpType::LOAD) return 6;
-    if (op == entity::OpType::OUTPUT) return 7;
-    if (op == entity::OpType::ROUTE) return 8;
+    if (op == entity::OpType::kNop) return 0;
+    if (op == entity::OpType::kAdd) return 1;
+    if (op == entity::OpType::kSub) return 2;
+    if (op == entity::OpType::kMul) return 3;
+    if (op == entity::OpType::kDiv) return 4;
+    if (op == entity::OpType::kConst) return 5;
+    if (op == entity::OpType::kLoad) return 6;
+    if (op == entity::OpType::kOutput) return 7;
+    if (op == entity::OpType::kRoute) return 8;
     return 0;
   };
 
@@ -91,7 +91,7 @@ TEST(VerilogSimulatorTest, synchronous_CGRA_test) {
         cgra->config_op = GetOpIndex(cgra_config.operation_type);
         cgra->config_const_data = cgra_config.const_value;
 
-        if (cgra_config.operation_type == entity::OpType::OUTPUT) {
+        if (cgra_config.operation_type == entity::OpType::kOutput) {
           output_config_id = config_id;
         }
       } else if (config_size + 1 <= cycle && cycle <= config_size + 20) {

--- a/src/create_database.cpp
+++ b/src/create_database.cpp
@@ -49,9 +49,10 @@ std::vector<entity::MRRGConfig> GetMRRGOfSubCGRA(
 
         if (target_mrrg_config.memory_io != entity::MRRGMemoryIOType::kAll) {
           int memory_access_pe_num = 0;
-          if (mrrg_config.memory_io == entity::kBothEnds) {
+          if (mrrg_config.memory_io == entity::MRRGMemoryIOType::kBothEnds) {
             memory_access_pe_num = 2 * row_num * context_size;
-          } else if (mrrg_config.memory_io == entity::kOneEnd) {
+          } else if (mrrg_config.memory_io ==
+                     entity::MRRGMemoryIOType::kOneEnd) {
             memory_access_pe_num = row_num * context_size;
           }
           if (memory_access_pe_num < memory_access_node_num) {

--- a/src/verilator_synchronous_CGRA.cpp
+++ b/src/verilator_synchronous_CGRA.cpp
@@ -92,15 +92,15 @@ int main(int argc, char** argv) {
   };
 
   auto GetOpIndex = [](entity::OpType op) {
-    if (op == entity::OpType::NOP) return 0;
-    if (op == entity::OpType::ADD) return 1;
-    if (op == entity::OpType::SUB) return 2;
-    if (op == entity::OpType::MUL) return 3;
-    if (op == entity::OpType::DIV) return 4;
-    if (op == entity::OpType::CONST) return 5;
-    if (op == entity::OpType::LOAD) return 6;
-    if (op == entity::OpType::OUTPUT) return 7;
-    if (op == entity::OpType::ROUTE) return 8;
+    if (op == entity::OpType::kNop) return 0;
+    if (op == entity::OpType::kAdd) return 1;
+    if (op == entity::OpType::kSub) return 2;
+    if (op == entity::OpType::kMul) return 3;
+    if (op == entity::OpType::kDiv) return 4;
+    if (op == entity::OpType::kConst) return 5;
+    if (op == entity::OpType::kLoad) return 6;
+    if (op == entity::OpType::kOutput) return 7;
+    if (op == entity::OpType::kRoute) return 8;
     return 0;
   };
 
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
         cgra->config_op = GetOpIndex(cgra_config.operation_type);
         cgra->config_const_data = cgra_config.const_value;
 
-        if (cgra_config.operation_type == entity::OpType::OUTPUT) {
+        if (cgra_config.operation_type == entity::OpType::kOutput) {
           output_PE_id = entity::PEPositionId(row_id, column_id);
         }
       } else if (config_size + 1 <= cycle && cycle <= config_size + 20) {


### PR DESCRIPTION
## Summary
- Convert project C++ enum definitions to `enum class` where they were still unscoped.
- Rename enum values to Google-style `k...` names, including `OpType`, `RemappingMode`, `RotateOp`, `RotateType`, and `PEType`.
- Update C++ call sites and tests to use the new scoped names while preserving existing string serialization such as `"ADD"`, `"dp"`, and rotation log values.

## Context
Fixes #1. The issue asks for enum values such as opcodes to follow the Google Coding Style pattern like `kOk`, `kOutOfMemory`, etc.

## Validation
- `ninja -C /tmp/codex-proj-build-issue126`
- `pre-commit run --all-files`
- `ctest --test-dir /tmp/codex-proj-build-issue126 --output-on-failure -E "SimulatorTest|VerilogSynchronousCGRATest|RemapperTest"`

Full `ctest --test-dir /tmp/codex-proj-build-issue126 --output-on-failure` still has fixture-path failures in `SimulatorTest`, `VerilogSynchronousCGRATest`, and this main-based branch's `RemapperTest`; the remaining 10 tests pass.