### PR TITLE
Add optional stdout debug logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(third_party)
 
 enable_testing()
 
+add_subdirectory(common/logging)
 add_subdirectory(entity)
 add_subdirectory(io)
 add_subdirectory(mapper)
@@ -47,8 +48,9 @@ verilate(verilator_synchronous_CGRA TRACE INCLUDE_DIRS
 set_property(TARGET verilator_synchronous_CGRA PROPERTY CXX_STANDARD 17)
 target_compile_options(verilator_synchronous_CGRA INTERFACE -Wall -Wextra
                                                             -Wno-deprecated)
-target_link_libraries(verilator_synchronous_CGRA
-                      PRIVATE io entity mapper cpp_simulator cxxopts::cxxopts)
+target_link_libraries(
+  verilator_synchronous_CGRA PRIVATE common_logging io entity mapper
+                                     cpp_simulator cxxopts::cxxopts)
 add_executable(remapping src/remapping.cpp)
 set_property(TARGET remapping PROPERTY CXX_STANDARD 17)
 target_compile_options(remapping INTERFACE -Wall -Wextra -Wno-deprecated)

--- a/common/logging/CMakeLists.txt
+++ b/common/logging/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(common_logging INTERFACE IMPORTED GLOBAL)
+set_property(TARGET common_logging PROPERTY CXX_STANDARD 17)
+set_target_properties(
+  common_logging PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                            ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_compile_options(common_logging INTERFACE -Wall -Wextra -Wno-deprecated)

--- a/common/logging/include/common/logging/debug_logger.hpp
+++ b/common/logging/include/common/logging/debug_logger.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <iostream>
+
+namespace common::logging {
+
+class DebugLogger {
+ public:
+  explicit DebugLogger(bool enabled) : enabled_(enabled) {}
+
+  template <typename T>
+  DebugLogger& operator<<(const T& value) {
+    if (enabled_) std::cout << value;
+    return *this;
+  }
+
+  using StreamManipulator = std::ostream& (*)(std::ostream&);
+  DebugLogger& operator<<(StreamManipulator manipulator) {
+    if (enabled_) manipulator(std::cout);
+    return *this;
+  }
+
+ private:
+  bool enabled_;
+};
+
+}  // namespace common::logging

--- a/src/verilator_synchronous_CGRA.cpp
+++ b/src/verilator_synchronous_CGRA.cpp
@@ -2,6 +2,7 @@
 #include <verilated.h>
 #include <verilated_vcd_c.h>
 
+#include <common/logging/debug_logger.hpp>
 #include <cxxopts.hpp>
 #include <io/architecture_io.hpp>
 #include <io/dfg_io.hpp>
@@ -22,13 +23,16 @@ int main(int argc, char** argv) {
                                      "Path to the mapper config json file",
                                      cxxopts::value<std::string>())(
       "fst_output_file", "Path to write the waveform output file",
-      cxxopts::value<std::string>())("h,help", "Print usage");
+      cxxopts::value<std::string>())(
+      "log_output", "Print debug log messages to stdout")("h,help",
+                                                          "Print usage");
 
   std::string dfg_dot_file_path;
   std::string mrrg_file_path;
   std::string mapping_file_path;
   std::string mapper_config_file_path;
   std::string fst_output_file_path;
+  bool log_output = false;
   try {
     const auto result = options.parse(argc, argv);
     if (result.count("help")) {
@@ -40,11 +44,13 @@ int main(int argc, char** argv) {
     mapping_file_path = result["mapping_file"].as<std::string>();
     mapper_config_file_path = result["mapper_config"].as<std::string>();
     fst_output_file_path = result["fst_output_file"].as<std::string>();
+    log_output = result.count("log_output") > 0;
   } catch (const cxxopts::exceptions::exception& e) {
     std::cerr << "invalid arguments: " << e.what() << std::endl;
     std::cerr << options.help();
     return 1;
   }
+  common::logging::DebugLogger logger(log_output);
 
   // create mapping
   std::shared_ptr<entity::DFG> dfg_ptr = std::make_shared<entity::DFG>();
@@ -183,16 +189,16 @@ int main(int argc, char** argv) {
         cgra->start_exec = 0;
         int exe_cycle = cycle - (config_size + 61);
         if (exe_cycle % 4 == 0) {
-          std::cout << "-- step " << exe_cycle / 4 << " --" << std::endl;
-          std::cout << cgra->DEBUG_memory_read_address[1][0] << std::endl;
-          std::cout << "output/input1/input2/index1/index2" << std::endl;
+          logger << "-- step " << exe_cycle / 4 << " --" << std::endl;
+          logger << cgra->DEBUG_memory_read_address[1][0] << std::endl;
+          logger << "output/input1/input2/index1/index2" << std::endl;
           for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 4; j++) {
-              std::cout << cgra->pe_output[i][j] << "/"
-                        << cgra->DEBUG_input_PE_index_1[i][j] + 0 << "/"
-                        << cgra->DEBUG_input_PE_index_2[i][j] + 0 << " ";
+              logger << cgra->pe_output[i][j] << "/"
+                     << cgra->DEBUG_input_PE_index_1[i][j] + 0 << "/"
+                     << cgra->DEBUG_input_PE_index_2[i][j] + 0 << " ";
             }
-            std::cout << std::endl;
+            logger << std::endl;
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add a small `DebugLogger` wrapper for optional stdout debug output.
- Add `--log_output` to `verilator_synchronous_CGRA` so existing debug messages are printed only when requested.
- Keep normal help and argument error output unchanged.

## Validation
- `cmake -S /home/ubuntu/codex-proj/codex-worktrees/debug-logger -B /tmp/codex-proj-debug-logger-build -G Ninja`
- `ninja -C /tmp/codex-proj-debug-logger-build verilator_synchronous_CGRA`
- `/tmp/codex-proj-debug-logger-build/verilator_synchronous_CGRA --help`
- pre-commit hooks during commit and push, including clang-format and ctest

## Scope
This PR intentionally contains only the Logger-related change in `src/verilator_synchronous_CGRA.cpp`. Simulator/root-cause debugging is being handled separately.